### PR TITLE
Use system foreground and background colors

### DIFF
--- a/ShipsClock/ClockBackground.swift
+++ b/ShipsClock/ClockBackground.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 struct ClockBackground: View {
-    let borderColor = Color.black
     var radius: Double
     
     var body: some View {
@@ -21,12 +20,10 @@ struct ClockBackground: View {
     }
 
     var border: some View {
-        Circle().stroke(borderColor, lineWidth: 4)
+        Circle().stroke(lineWidth: 4)
     }
     
     struct HourTicks: View {
-        var tickColor = Color.black
-        
         var radius : Double
         var hourInterval : Int
         var widthMultiplier : Int
@@ -43,7 +40,7 @@ struct ClockBackground: View {
                 }
             }
             .stroke(lineWidth: CGFloat(widthMultiplier) * baseLineWidth)
-            .fill(self.tickColor)
+            .fill()
         }
     }
 

--- a/ShipsClock/ClockHands.swift
+++ b/ShipsClock/ClockHands.swift
@@ -60,7 +60,7 @@ struct ClockHands: View {
                 path.addLine(to: CGPoint(x: -3, y: 0))
                 path.addLine(to: CGPoint(x: 0, y: -3))
                 path.addLine(to: CGPoint(x: 0, y: 3))
-            }.transform(transform).fill(Color.black)
+            }.transform(transform).fill()
         }
     }
     
@@ -118,7 +118,7 @@ struct ClockHands: View {
             return Circle()
                 .size(width: centerSize, height: centerSize)
                 .offset(x: offset, y: offset)
-                .fill(Color.white)
+                .fill(Color(UIColor.systemBackground))
         }
     }
 }


### PR DESCRIPTION
Fixes #8 
Replace black and white with default (system foreground) and system background color.

Thus enables dark mode render to look the reverse of light mode render.

![Simulator Screen Shot - iPhone 8 - 2020-07-05 at 11 52 51](https://user-images.githubusercontent.com/1066662/86536522-49d14c00-beb6-11ea-926b-646b186ed1d4.png)
