### PR TITLE
Refactor and test location tracker for velocity

### DIFF
--- a/ShipsClock.xcodeproj/project.pbxproj
+++ b/ShipsClock.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		6F5F631C24D47E3A00172BC4 /* MoonCalcTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5F631B24D47E3A00172BC4 /* MoonCalcTest.swift */; };
 		6F5F631D24D481B100172BC4 /* MoonCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5F631924D1E4B900172BC4 /* MoonCalculator.swift */; };
 		6F77AF04244FDD4E0070DB57 /* ShipsClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F77AF03244FDD4E0070DB57 /* ShipsClock.swift */; };
+		6F7DAC21259430830053E24C /* LocationFormatterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7DAC20259430830053E24C /* LocationFormatterTest.swift */; };
+		6F7DAC26259431510053E24C /* LocationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7DAC25259431510053E24C /* LocationFormatter.swift */; };
+		6F7DAC27259431510053E24C /* LocationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7DAC25259431510053E24C /* LocationFormatter.swift */; };
 		6F8FEC8F2469B3D300A1FAE7 /* TimerRinger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8FEC8E2469B3D300A1FAE7 /* TimerRinger.swift */; };
 		6F8FEC97246C1F9F00A1FAE7 /* LocationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8FEC96246C1F9F00A1FAE7 /* LocationTracker.swift */; };
 		6F8FEC99246C4FE000A1FAE7 /* SituationDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8FEC98246C4FE000A1FAE7 /* SituationDisplay.swift */; };
@@ -108,6 +111,8 @@
 		6F725BF8255D796200CC85A3 /* ELPMPP02.for */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.fortran; path = ELPMPP02.for; sourceTree = "<group>"; };
 		6F725C03255D8A8900CC85A3 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
 		6F77AF03244FDD4E0070DB57 /* ShipsClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipsClock.swift; sourceTree = "<group>"; };
+		6F7DAC20259430830053E24C /* LocationFormatterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationFormatterTest.swift; sourceTree = "<group>"; };
+		6F7DAC25259431510053E24C /* LocationFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationFormatter.swift; sourceTree = "<group>"; };
 		6F8FEC8E2469B3D300A1FAE7 /* TimerRinger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerRinger.swift; sourceTree = "<group>"; };
 		6F8FEC96246C1F9F00A1FAE7 /* LocationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationTracker.swift; sourceTree = "<group>"; };
 		6F8FEC98246C4FE000A1FAE7 /* SituationDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SituationDisplay.swift; sourceTree = "<group>"; };
@@ -214,6 +219,7 @@
 				6F1BBB4F24B7987B0092A54D /* Arcs.swift */,
 				6F1BBB4A24B779ED0092A54D /* Julian.swift */,
 				6F8FEC96246C1F9F00A1FAE7 /* LocationTracker.swift */,
+				6F7DAC25259431510053E24C /* LocationFormatter.swift */,
 				6F24FD9D245D2D6A0006590A /* ShipsBell.swift */,
 				6F8FEC8E2469B3D300A1FAE7 /* TimerRinger.swift */,
 				6FE9AFDE243FBB79002B45BA /* ClockFace.swift */,
@@ -249,6 +255,7 @@
 				6F404121248BD0D500B1BF5D /* ShipsClockTests-Bridging-Header.h */,
 				6F1BBB4C24B77AB10092A54D /* JulianDayTest.swift */,
 				6F5F631B24D47E3A00172BC4 /* MoonCalcTest.swift */,
+				6F7DAC20259430830053E24C /* LocationFormatterTest.swift */,
 			);
 			path = ShipsClockTests;
 			sourceTree = "<group>";
@@ -417,6 +424,7 @@
 				6F8FEC99246C4FE000A1FAE7 /* SituationDisplay.swift in Sources */,
 				6F1BBB5024B7987B0092A54D /* Arcs.swift in Sources */,
 				6FE9AFAF243F9CA8002B45BA /* SceneDelegate.swift in Sources */,
+				6F7DAC26259431510053E24C /* LocationFormatter.swift in Sources */,
 				6FCCEE882497051A00F18212 /* CelestialComputer.swift in Sources */,
 				6FCCEE85249652D800F18212 /* SunCalculator.swift in Sources */,
 				6FE9AFB1243F9CA8002B45BA /* ContentView.swift in Sources */,
@@ -436,11 +444,13 @@
 				6F1BBB5224B79B2A0092A54D /* ArcsTest.swift in Sources */,
 				6F1BBB5324B79C070092A54D /* Arcs.swift in Sources */,
 				6FAECDB025658BFC00B91A82 /* EclToEquTest.swift in Sources */,
+				6F7DAC27259431510053E24C /* LocationFormatter.swift in Sources */,
 				6FAC63C1256C424E00C2C834 /* MoonPhase.swift in Sources */,
 				6F47588A2561608200E78298 /* CelestialTime.swift in Sources */,
 				6F5F631C24D47E3A00172BC4 /* MoonCalcTest.swift in Sources */,
 				6F1BBB4D24B77AB10092A54D /* JulianDayTest.swift in Sources */,
 				6FAECDBB2566C0E800B91A82 /* CelestialTimeTest.swift in Sources */,
+				6F7DAC21259430830053E24C /* LocationFormatterTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ShipsClock/LocationFormatter.swift
+++ b/ShipsClock/LocationFormatter.swift
@@ -1,0 +1,69 @@
+//
+  // ShipsClock
+  // Created by Douglas Lovell on 12/23/20.
+  // Copyright © 2020 Douglas Lovell
+  /*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  */
+  
+import Foundation
+import CoreLocation
+
+struct LocationFormatter {
+
+    static let compassPoints = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"]
+
+    static func degreesMinutesSeconds(degrees: CLLocationDegrees) -> (Int, Int, Int) {
+        let mf = degrees.truncatingRemainder(dividingBy: 1.0) * 60.0
+        let s = round(mf.truncatingRemainder(dividingBy: 1.0) * 60.0)
+        return (Int(degrees), Int(mf), Int(s))
+    }
+    
+    static func formatDMS(degrees latorlon: CLLocationDegrees, isLongitude isLon: Bool) -> String {
+        var dForm: String
+        if isLon {
+            dForm = latorlon < 0 ? "W %03d" : "E %03d"
+        } else {
+            dForm = latorlon < 0 ? "S  %02d" : "N  %02d"
+        }
+        let (d, m, s) = degreesMinutesSeconds(degrees: abs(latorlon))
+        return String(format: "\(dForm)º %02d' %02d\"", locale: Locale.current, arguments: [d, m, s])
+    }
+    
+    static func courseCompassPoint(_ course: CLLocationDegrees) -> String {
+        let point = Int(course.advanced(by: 11.25).truncatingRemainder(dividingBy: 360.0) / 22.5)
+        if (0 <= point && point < LocationFormatter.compassPoints.count) {
+            return LocationFormatter.compassPoints[point]
+        } else {
+            return "\(course)?"
+        }
+    }
+    
+    // report velicity stored in m/s as knots, nautical miles per hour
+    static func velocityInKnots(_ vms: CLLocationSpeed) -> Float {
+        return (0.0 <= vms) ? Float(vms * 3600.0 / 1852.0) : 0.0
+    }
+    
+    static func formatCourseAndSpeed(_ course: CLLocationDirection, _ velocity: CLLocationSpeed) -> String {
+        if (0.0 <= course && 0.0 < velocity) {
+            let ccp = courseCompassPoint(course)
+            let kts = velocityInKnots(velocity)
+            return String.localizedStringWithFormat(
+                "%.1f kts %@",
+                kts, ccp
+            )
+        } else {
+            return("No way on")
+        }
+    }
+}

--- a/ShipsClock/LocationTracker.swift
+++ b/ShipsClock/LocationTracker.swift
@@ -28,57 +28,11 @@ class LocationTracker: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var velocity: CLLocationSpeed
     @Published var course: CLLocationDirection
 
-    static let compassPoints = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"]
-
     override init() {
         latitude = 0.0
         longitude = 0.0
         velocity = 0.0
         course = 0.0
-    }
-    
-    static func degreesMinutesSeconds(degrees: CLLocationDegrees) -> (Int, Int, Int) {
-        let mf = degrees.truncatingRemainder(dividingBy: 1.0) * 60.0
-        let s = round(mf.truncatingRemainder(dividingBy: 1.0) * 60.0)
-        return (Int(degrees), Int(mf), Int(s))
-    }
-    
-    static func format(degrees latorlon: CLLocationDegrees, isLongitude isLon: Bool) -> String {
-        var dForm: String
-        if isLon {
-            dForm = latorlon < 0 ? "W %03d" : "E %03d"
-        } else {
-            dForm = latorlon < 0 ? "S  %02d" : "N  %02d"
-        }
-        let (d, m, s) = degreesMinutesSeconds(degrees: abs(latorlon))
-        return String(format: "\(dForm)º %02d' %02d\"", locale: Locale.current, arguments: [d, m, s])
-    }
-    
-    func courseCompassPoint() -> String {
-        let point = Int(course.advanced(by: 11.25).truncatingRemainder(dividingBy: 360.0) / 22.5)
-        if (0 <= point && point < LocationTracker.compassPoints.count) {
-            return LocationTracker.compassPoints[point]
-        } else {
-            return "\(course)?"
-        }
-    }
-    
-    // report velicity stored in m/s as knots, nautical miles per hour
-    func velocityInKnots() -> Float {
-        return (0.0 <= velocity) ? Float(velocity * 360.0 / 1852.0) : 0.0
-    }
-    
-    func courseAndSpeed() -> String {
-        if (0.0 <= course && 0.0 < velocity) {
-            let ccp = courseCompassPoint()
-            let kts = velocityInKnots()
-            return String.localizedStringWithFormat(
-                "%.1f kts %@",
-                kts, ccp
-            )
-        } else {
-            return("No way on")
-        }
     }
     
     func seekPermission() {

--- a/ShipsClock/SituationDisplay.swift
+++ b/ShipsClock/SituationDisplay.swift
@@ -28,9 +28,9 @@ struct SituationDisplay: View {
         VStack(alignment: .leading, spacing: nil) {
             if location.isValidLocation {
                 VStack {
-                    Text(LocationTracker.format(degrees: location.latitude, isLongitude: false))
-                    Text(LocationTracker.format(degrees: location.longitude, isLongitude: true))
-                    Text(location.courseAndSpeed())
+                    Text(LocationFormatter.formatDMS(degrees: location.latitude, isLongitude: false))
+                    Text(LocationFormatter.formatDMS(degrees: location.longitude, isLongitude: true))
+                    Text(LocationFormatter.formatCourseAndSpeed(location.course, location.velocity))
                 }.lineLimit(1)
                     .font(.system(size: CGFloat(displayWidth / 10.0), weight: .bold, design: .monospaced))
                     .minimumScaleFactor(0.5)

--- a/ShipsClockTests/LocationFormatterTest.swift
+++ b/ShipsClockTests/LocationFormatterTest.swift
@@ -1,0 +1,32 @@
+//
+  // ShipsClockTests
+  // Created by Douglas Lovell on 23/12/20.
+  // Copyright © 2020 Douglas Lovell
+  /*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  */
+  
+
+import XCTest
+
+class LocationFormatterTest: XCTestCase {
+
+    func testVelocityInKnots() throws {
+        let prec = 1.0e-02
+        XCTAssertEqual(Double(LocationFormatter.velocityInKnots(1.0)), 1.94, accuracy: prec)
+        XCTAssertEqual(Double(LocationFormatter.velocityInKnots(12.0)), 23.32, accuracy: prec)
+        XCTAssertEqual(Double(LocationFormatter.velocityInKnots(10.25)), 19.92, accuracy: prec)
+        XCTAssertEqual(Double(LocationFormatter.velocityInKnots(0.25)), 0.49, accuracy: prec)
+    }
+
+}


### PR DESCRIPTION
- Extract the situation display formatting code from the location tracking code
- Test the velocity conversion from meters per second to knots

It turns out the conversion of seconds to hours used a factor of 360.0. Sixty seconds per minute times sixty minutes per hour is 3600.0, not 360.0. The corrected code passes the tests.

closes #17 